### PR TITLE
[fix] add webm extension for safari

### DIFF
--- a/src/server/api/routers/video.ts
+++ b/src/server/api/routers/video.ts
@@ -88,7 +88,7 @@ export const videoRouter = createTRPCRouter({
 
       const getObjectCommand = new GetObjectCommand({
         Bucket: env.AWS_BUCKET_NAME,
-        Key: video.userId + "/" + video.id,
+        Key: video.userId + "/" + video.id + ".webm",
       });
 
       const signedUrl = await getSignedUrl(s3, getObjectCommand);
@@ -156,7 +156,7 @@ export const videoRouter = createTRPCRouter({
         s3,
         new PutObjectCommand({
           Bucket: env.AWS_BUCKET_NAME,
-          Key: session.user.id + "/" + video.id,
+          Key: session.user.id + "/" + video.id + ".webm",
         })
       );
 
@@ -345,7 +345,7 @@ export const videoRouter = createTRPCRouter({
       const deleteVideoObject = await s3.send(
         new DeleteObjectCommand({
           Bucket: env.AWS_BUCKET_NAME,
-          Key: session.user.id + "/" + input.videoId,
+          Key: session.user.id + "/" + input.videoId + ".webm",
         })
       );
 


### PR DESCRIPTION
I found that viewing videos in Safari was broken when I ran this with AWS S3 as a backend. I came across [this blog](https://corevo.io/the-weird-case-of-video-streaming-in-safari/), added `.webm` extensions to the videos, and 🎉  - this seemed to fix it. I have no idea if this fixes it for Backblaze, but this may be helpful.

Maybe this closes: https://github.com/MarconLP/snapify/issues/12, maybe not.

Proof:

<img width="1381" alt="image" src="https://github.com/user-attachments/assets/20b37407-e734-404b-8d5f-3f1d4325b888">
